### PR TITLE
fix bug that InfoHub does not show post on iOS9

### DIFF
--- a/malaria-ios/Information/EndpointType.swift
+++ b/malaria-ios/Information/EndpointType.swift
@@ -21,10 +21,14 @@ import Foundation
 /// - `Objectives`
 /// - `Goals`
 public enum EndpointType : String{
-    case BaseUrl = "http://pc-web-dev.systers.org/"
+    #if DEBUG
+    case BaseUrl = "https://systerspcweb.herokuapp.com/"
+    #else
+    case BaseUrl = "https://pc-web-dev.systers.org/"
+    #endif
     
     case Api = "api"
-    case Posts = "posts"
+    case Posts = "posts/"
     case Revposts = "revposts"
     case Regions = "regions"
     case Sectors = "sectors"

--- a/malaria-ios/Managers/SyncManager.swift
+++ b/malaria-ios/Managers/SyncManager.swift
@@ -3,21 +3,13 @@ import SwiftyJSON
 
 /// Responsible for syncing remote server with CoreData
 public class SyncManager : CoreDataContextManager{
+
     private let user = "TestUser"
     private let password = "password"
     
     /// Init
     public override init(context: NSManagedObjectContext!){
-        super.init(context: context)
-        
-        // set up the base64-encoded credentials
-        let loginString = NSString(format: "%@:%@", user, password)
-        let loginData: NSData = loginString.dataUsingEncoding(NSUTF8StringEncoding)!
-        let base64LoginString = loginData.base64EncodedStringWithOptions([])
-        
-        let key = "Authorization"
-        let value = "Basic \(base64LoginString)"
-        Alamofire.Manager.sharedInstance.session.configuration.HTTPAdditionalHeaders!.updateValue(value, forKey: key)
+        super.init(context: context)        
     }
     
     /// dictionary with key full endpoint url path and object an instance of `Endpoint`
@@ -73,14 +65,21 @@ public class SyncManager : CoreDataContextManager{
         }
     }
     
-    
+    private func headers() -> [String : String] {
+        
+        // set up the base64-encoded credentials
+        let loginString = NSString(format: "%@:%@", user, password)
+        let loginData: NSData = loginString.dataUsingEncoding(NSUTF8StringEncoding)!
+        let base64LoginString = loginData.base64EncodedStringWithOptions([])
+        
+        return ["Authorization":"Basic \(base64LoginString)"]
+    }
     
     
     private func remoteFetch(endpoint: Endpoint, save: Bool = false, completion: ((url: String, error: NSError?)->())? = nil){
         Logger.Info("Syncing: \(endpoint.path)")
         
-        
-        Alamofire.request(.GET, endpoint.path, parameters: ["format": "json"]).validate().responseJSON { response in
+        Alamofire.request(.GET, endpoint.path, headers: headers(), parameters: ["format": "json"]).validate().responseJSON { response in
             var resultError: NSError? = nil
             
             switch response.result {


### PR DESCRIPTION
#### What's this PR do?

pass the headers into the request
#### Where should the reviewer start?

https://github.com/systers/malaria-app-ios/compare/develop...tjnet:infohub_shows_post_on_ios_9?expand=1#diff-2f4902ea81db61ab596ef699cf21bbd3R82
#### How should this be manually tested?
- [x] InfoHub shows post successfully on DEBUG build
- [x] ~~InfoHub shows post successfully on RELEASE build~~
  - I could not test this. Because I could not access production API via app.
#### Any background context you want to provide?

[HTTPAdditionalHeaders is not successful on iOS9 · Issue #694 · Alamofire/Alamofire](https://github.com/Alamofire/Alamofire/issues/694)
#### What are the relevant tickets?

[GSoC 2016 InfoHub only shows post on 8.X · Issue #35 · systers/malaria-app-ios](https://github.com/systers/malaria-app-ios/issues/35)
#### Screenshots

![2016-04-04 0 56 14](https://cloud.githubusercontent.com/assets/901084/14233321/18b3faac-fa00-11e5-8887-5ca1f03622bb.png)
